### PR TITLE
Implementation of InfiniteCapacityBuffer

### DIFF
--- a/packages/channel/src/__tests__/buffers.ts
+++ b/packages/channel/src/__tests__/buffers.ts
@@ -1,4 +1,9 @@
-import { DroppingBuffer, FixedBuffer, SlidingBuffer } from "../index";
+import {
+  DroppingBuffer,
+  FixedBuffer,
+  SlidingBuffer,
+  InfiniteCapacityBuffer
+} from "../index";
 
 describe("ChannelBuffer", () => {
   test("FixedBuffer", () => {
@@ -42,6 +47,24 @@ describe("ChannelBuffer", () => {
     expect([buffer.empty, buffer.full]).toEqual([false, false]);
     expect(buffer.remove()).toEqual(1);
     expect(buffer.remove()).toEqual(2);
+    expect([buffer.empty, buffer.full]).toEqual([true, false]);
+    expect(() => buffer.remove()).toThrow();
+  });
+
+  test("InfiniteCapacityBuffer", () => {
+    const buffer = new InfiniteCapacityBuffer<number>();
+    expect([buffer.empty, buffer.full]).toEqual([true, false]);
+
+    for (let i = 0; i < 100; i++) {
+      buffer.add(i + 1);
+    }
+
+    expect([buffer.empty, buffer.full]).toEqual([false, false]);
+
+    for (let i = 0; i < 100; i++) {
+      expect(buffer.remove()).toEqual(i + 1);
+    }
+
     expect([buffer.empty, buffer.full]).toEqual([true, false]);
     expect(() => buffer.remove()).toThrow();
   });

--- a/packages/channel/src/buffers.ts
+++ b/packages/channel/src/buffers.ts
@@ -93,3 +93,27 @@ export class DroppingBuffer<T> implements ChannelBuffer<T> {
     return this.arr.shift()!;
   }
 }
+
+export class InfiniteCapacityBuffer<T> implements ChannelBuffer<T> {
+  private arr: T[] = [];
+
+  public get empty(): boolean {
+    return this.arr.length === 0;
+  }
+
+  public get full(): boolean {
+    return false;
+  }
+
+  public add(value: T): void {
+    this.arr.push(value);
+  }
+
+  public remove(): T {
+    if (this.empty) {
+      throw new Error("Buffer empty");
+    }
+
+    return this.arr.shift()!;
+  }
+}

--- a/packages/channel/src/index.ts
+++ b/packages/channel/src/index.ts
@@ -3,11 +3,12 @@ export {
   DroppingBuffer,
   FixedBuffer,
   SlidingBuffer,
+  InfiniteCapacityBuffer
 } from "./buffers";
 
 export {
   Channel,
   ChannelExecutor,
   ChannelOverflowError,
-  MAX_QUEUE_LENGTH,
+  MAX_QUEUE_LENGTH
 } from "./channel";


### PR DESCRIPTION
There are other kinds of buffers available already. This one is special because it ensures that no data will be lost in the process of consuming channel.

If incorrectly used might cause a memory leak but there are a bunch of use-cases where it's important to not miss something. Might be worth mentioning in docs or something.

Not sure if `InfiniteCapacityBuffer` is the best name so I am open for discussion.