### PR TITLE
Parameterize next/return

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 node_modules
 lib
 coverage
-.rpt2_cache
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
-lerna-debug.log*

--- a/package.json
+++ b/package.json
@@ -10,8 +10,5 @@
     "build": "yarn workspaces run build",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test"
-  },
-  "devDependencies": {
-    "typescript": "^3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "build": "yarn workspaces run build",
     "lint": "yarn workspaces run lint",
     "test": "yarn workspaces run test"
+  },
+  "devDependencies": {
+    "typescript": "^3.6.2"
   }
 }

--- a/packages/limiters/package.json
+++ b/packages/limiters/package.json
@@ -33,7 +33,7 @@
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-config-recommended-plus-types": "^1.0.0",
-    "eslint-plugin-jest": "^22.17.0",
+    "eslint-plugin-jest": "^22.19.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",

--- a/packages/limiters/src/limiters.ts
+++ b/packages/limiters/src/limiters.ts
@@ -95,20 +95,20 @@ export function throttler(
 
     let stopped = false;
     stop.then(() => (stopped = true));
-    for await (let token of Repeater.race([semaphore(limit), stop])) {
+    for await (const token of Repeater.race([semaphore(limit), stop])) {
       if (stopped) {
         break;
       }
 
       leaking = leak();
-      token = { ...token, reset: start + wait };
-      tokens.add(token);
+      let token1: ThrottleToken = { ...token, reset: start + wait };
+      tokens.add(token1);
       if (cooldown && token.remaining === 0) {
         await Promise.race([stop, leaking]);
-        token = { ...token, remaining: limit };
+        token1 = { ...token1, remaining: limit };
       }
 
-      await push(token);
+      await push(token1);
     }
 
     tokens.clear();

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -32,7 +32,7 @@
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-config-recommended-plus-types": "^1.0.0",
-    "eslint-plugin-jest": "^22.17.0",
+    "eslint-plugin-jest": "^22.19.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",

--- a/packages/repeater/package.json
+++ b/packages/repeater/package.json
@@ -29,7 +29,7 @@
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-config-recommended-plus-types": "^1.0.0",
-    "eslint-plugin-jest": "^22.17.0",
+    "eslint-plugin-jest": "^22.19.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",

--- a/packages/repeater/src/buffers.ts
+++ b/packages/repeater/src/buffers.ts
@@ -1,12 +1,12 @@
 export interface RepeaterBuffer<T> {
   full: boolean;
   empty: boolean;
-  add(value: T): void;
-  remove(): T;
+  add(value: PromiseLike<T> | T): void;
+  remove(): PromiseLike<T> | T;
 }
 
 export class FixedBuffer<T> implements RepeaterBuffer<T> {
-  private arr: T[] = [];
+  private arr: (PromiseLike<T> | T)[] = [];
 
   get empty(): boolean {
     return this.arr.length === 0;
@@ -22,7 +22,7 @@ export class FixedBuffer<T> implements RepeaterBuffer<T> {
     }
   }
 
-  add(value: T): void {
+  add(value: PromiseLike<T> | T): void {
     if (this.full) {
       throw new Error("Buffer full");
     } else {
@@ -30,7 +30,7 @@ export class FixedBuffer<T> implements RepeaterBuffer<T> {
     }
   }
 
-  remove(): T {
+  remove(): PromiseLike<T> | T {
     if (this.empty) {
       throw new Error("Buffer empty");
     }
@@ -41,7 +41,7 @@ export class FixedBuffer<T> implements RepeaterBuffer<T> {
 
 // TODO: use a circular buffer here
 export class SlidingBuffer<T> implements RepeaterBuffer<T> {
-  private arr: T[] = [];
+  private arr: (PromiseLike<T> | T)[] = [];
 
   get empty(): boolean {
     return this.arr.length === 0;
@@ -57,7 +57,7 @@ export class SlidingBuffer<T> implements RepeaterBuffer<T> {
     }
   }
 
-  add(value: T): void {
+  add(value: PromiseLike<T> | T): void {
     while (this.arr.length >= this.capacity) {
       this.arr.shift();
     }
@@ -65,7 +65,7 @@ export class SlidingBuffer<T> implements RepeaterBuffer<T> {
     this.arr.push(value);
   }
 
-  remove(): T {
+  remove(): PromiseLike<T> | T {
     if (this.empty) {
       throw new Error("Buffer empty");
     }
@@ -75,7 +75,7 @@ export class SlidingBuffer<T> implements RepeaterBuffer<T> {
 }
 
 export class DroppingBuffer<T> implements RepeaterBuffer<T> {
-  private arr: T[] = [];
+  private arr: (PromiseLike<T> | T)[] = [];
 
   get empty(): boolean {
     return this.arr.length === 0;
@@ -91,13 +91,13 @@ export class DroppingBuffer<T> implements RepeaterBuffer<T> {
     }
   }
 
-  add(value: T): void {
+  add(value: PromiseLike<T> | T): void {
     if (this.arr.length < this.capacity) {
       this.arr.push(value);
     }
   }
 
-  remove(): T {
+  remove(): PromiseLike<T> | T {
     if (this.empty) {
       throw new Error("Buffer empty");
     }

--- a/packages/repeater/src/repeater.ts
+++ b/packages/repeater/src/repeater.ts
@@ -102,15 +102,15 @@ class RepeaterController<T, TReturn = any, TNext = any> {
     const push: Push<T> = this.push.bind(this);
     const stop: Stop = this.stop.bind(this) as Stop<TReturn>;
     const stopP = new Promise<TReturn>((onstop) => (this.onstop = onstop));
-    stop.then = stopP.then.bind(stopP);
-    stop.catch = stopP.catch.bind(stopP);
-    stop.finally = stopP.finally.bind(stopP);
     if (typeof Object.setPrototypeOf === "function") {
       Object.setPrototypeOf(stop, Promise.prototype);
     } else {
       (this as any).__proto__ = Promise.prototype;
     }
 
+    stop.then = stopP.then.bind(stopP);
+    stop.catch = stopP.catch.bind(stopP);
+    stop.finally = stopP.finally.bind(stopP);
     // Errors which occur in the executor take precedence over those passed to
     // this.stop, so calling this.stop with the caught error would be redundant.
     try {

--- a/packages/repeater/src/repeater.ts
+++ b/packages/repeater/src/repeater.ts
@@ -28,18 +28,12 @@ export class RepeaterOverflowError extends Error {
   }
 }
 
-// The current definition of AsyncIterator allows "any" to be passed to
-// next/return, so we use these type aliases to keep track of the arguments as
-// they flow through repeaters.
-// TODO: parameterize these types when this PR lands
-// (https://github.com/microsoft/TypeScript/pull/30790) Next is the argument
-// passed to AsyncIterator.next Return is the argument passed to
-// AsyncIterator.return
 export type Push<T, TNext = any> = (
   value: PromiseLike<T> | T,
-) => Promise<TNext>;
+) => Promise<TNext | undefined>;
 
-export type Stop<TReturn = any> = Promise<TReturn> & ((error?: any) => void);
+export type Stop<TReturn = any> = Promise<TReturn | undefined> &
+  ((error?: any) => void);
 
 export type RepeaterExecutor<T, TReturn = any, TNext = any> = (
   push: Push<T, TNext>,
@@ -80,7 +74,7 @@ class RepeaterController<T, TReturn = any, TNext = any> {
   // pending is continuously reassigned as the repeater is iterated. We use
   // this mechanism to make sure all iterations settle in order.
   private pending?: Promise<IteratorResult<T>>;
-  private execution?: PromiseLike<TReturn> | TReturn;
+  private execution?: Promise<TReturn>;
   private error?: any;
 
   constructor(
@@ -102,24 +96,18 @@ class RepeaterController<T, TReturn = any, TNext = any> {
     const push: Push<T> = this.push.bind(this);
     const stop: Stop = this.stop.bind(this) as Stop<TReturn>;
     const stopP = new Promise<TReturn>((onstop) => (this.onstop = onstop));
-    if (typeof Object.setPrototypeOf === "function") {
-      Object.setPrototypeOf(stop, Promise.prototype);
-    } else {
-      (this as any).__proto__ = Promise.prototype;
-    }
-
     stop.then = stopP.then.bind(stopP);
     stop.catch = stopP.catch.bind(stopP);
     stop.finally = stopP.finally.bind(stopP);
     // Errors which occur in the executor take precedence over those passed to
     // this.stop, so calling this.stop with the caught error would be redundant.
     try {
-      this.execution = this.executor(push, stop);
+      this.execution = Promise.resolve(this.executor(push, stop));
     } catch (err) {
       this.execution = Promise.reject(err);
     }
 
-    Promise.resolve(this.execution).catch(() => this.stop());
+    this.execution.catch(() => this.stop());
   }
 
   /**
@@ -129,7 +117,8 @@ class RepeaterController<T, TReturn = any, TNext = any> {
    */
   private async reject(err: any): Promise<IteratorResult<T>> {
     if (this.state >= RepeaterState.Stopped) {
-      return { value: await this.execution, done: true };
+      const value = await this.execution;
+      return { value, done: true };
     }
 
     this.finish().catch(() => {});
@@ -180,7 +169,7 @@ class RepeaterController<T, TReturn = any, TNext = any> {
    * Advances state to RepeaterState.Finished.
    */
   private finish(): Promise<IteratorResult<T>> {
-    const execution = this.execution;
+    const execution = Promise.resolve(this.execution);
     const error = this.error;
     if (this.state < RepeaterState.Finished) {
       if (this.state < RepeaterState.Stopped) {
@@ -195,7 +184,7 @@ class RepeaterController<T, TReturn = any, TNext = any> {
     }
 
     if (this.pending == null) {
-      this.pending = Promise.resolve(execution).then((value) => {
+      this.pending = execution.then((value) => {
         if (error == null) {
           return { value, done: true };
         }
@@ -209,7 +198,7 @@ class RepeaterController<T, TReturn = any, TNext = any> {
             return { value: undefined, done: true };
           }
 
-          return Promise.resolve(execution).then((value) => {
+          return execution.then((value) => {
             if (error == null) {
               return { value, done: true };
             }
@@ -221,7 +210,7 @@ class RepeaterController<T, TReturn = any, TNext = any> {
       );
     }
 
-    return this.pending!;
+    return this.pending;
   }
 
   /**
@@ -382,7 +371,10 @@ function iterators<T>(
   return iters;
 }
 
-type RepeaterControllerMap = WeakMap<Repeater<any>, RepeaterController<any>>;
+type RepeaterControllerMap<T = any, TReturn = any, TNext = any> = WeakMap<
+  Repeater<T, TReturn, TNext>,
+  RepeaterController<T, TReturn, TNext>
+>;
 
 const controllers: RepeaterControllerMap = new WeakMap();
 
@@ -391,7 +383,10 @@ export class Repeater<T, TReturn = any, TNext = any> {
     executor: RepeaterExecutor<T, TReturn, TNext>,
     buffer: RepeaterBuffer<PromiseLike<T> | T> = new FixedBuffer(0),
   ) {
-    controllers.set(this, new RepeaterController(executor, buffer));
+    controllers.set(
+      this,
+      new RepeaterController<T, TReturn, TNext>(executor, buffer),
+    );
   }
 
   next(value?: TNext): Promise<IteratorResult<T>> {

--- a/packages/timers/package.json
+++ b/packages/timers/package.json
@@ -32,7 +32,7 @@
     "eslint": "^6.5.1",
     "eslint-config-prettier": "^6.4.0",
     "eslint-config-recommended-plus-types": "^1.0.0",
-    "eslint-plugin-jest": "^22.17.0",
+    "eslint-plugin-jest": "^22.19.0",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^24.9.0",
     "prettier": "^1.18.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1201,10 +1201,10 @@ eslint-config-recommended-plus-types@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-recommended-plus-types/-/eslint-config-recommended-plus-types-1.0.0.tgz#aaf8e6d7d6b0cef98b2cf6aae6b7c7c059d2b4c8"
   integrity sha512-LKFuUDjAmIoSLV+DmyXFHpDg61f3tYFak63r/Od1WrntMwZOOeiSXaiWTsrXh1BK+UUEz3Wr6VUtoJ7i6C6fUA==
 
-eslint-plugin-jest@^22.17.0:
-  version "22.17.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.17.0.tgz#dc170ec8369cd1bff9c5dd8589344e3f73c88cf6"
-  integrity sha512-WT4DP4RoGBhIQjv+5D0FM20fAdAUstfYAf/mkufLNTojsfgzc5/IYW22cIg/Q4QBavAZsROQlqppiWDpFZDS8Q==
+eslint-plugin-jest@^22.19.0:
+  version "22.19.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.19.0.tgz#0cf90946a8c927d40a2c64458c89bb635d0f2a0b"
+  integrity sha512-4zUc3rh36ds0SXdl2LywT4YWA3zRe8sfLhz8bPp8qQPIKvynTTkNGwmSCMpl5d9QiZE2JxSinGF+WD8yU+O0Lg==
   dependencies:
     "@typescript-eslint/experimental-utils" "^1.13.0"
 


### PR DESCRIPTION
Closes #17
- Upgrades local typescript version to 3.6.2
- Adds `TReturn` and `TNext` type parameters

TODO: figure out if we want to use the new `IteratorResult`/`AsyncIterator` type args. Doing this would force typescript users to use typescript 3.6.2 or later or provide their own type shim.