### PR TITLE
Pubsub build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [pubsub@0.3.2] - 2019-10-13
+- Fixed build error in @repeaterjs/pubsub
+
 ## [timers@0.3.1] - 2019-06-29
 ## [limiters@0.3.1] - 2019-06-29
 ## [pubsub@0.3.1] - 2019-06-29

--- a/packages/pubsub/package.json
+++ b/packages/pubsub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repeaterjs/pubsub",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "A generic pubsub class, implemented with repeaters",
   "repository": {
     "type": "git",
@@ -11,9 +11,9 @@
   "files": [
     "/lib"
   ],
-  "main": "lib/repeater.cjs.js",
-  "module": "lib/repeater.esm.js",
-  "types": "lib/repeater.d.ts",
+  "main": "lib/pubsub.cjs.js",
+  "module": "lib/pubsub.esm.js",
+  "types": "lib/pubsub.d.ts",
   "scripts": {
     "prebuild": "yarn run clean",
     "build": "rollup -c ../../rollup.config.js",


### PR DESCRIPTION
Fixes a build error which caused a type error in typescript when importing `@repeaterjs/pubsub`.