### PR TITLE
Make repeaters with non-empty buffers throw when an error is thrown in via Repeater.prototype.throw

### DIFF
--- a/packages/repeater/src/__tests__/repeater.ts
+++ b/packages/repeater/src/__tests__/repeater.ts
@@ -1261,7 +1261,10 @@ describe("Repeater", () => {
     await expect(repeater.throw(error)).rejects.toBe(error);
     await expect(repeater.next()).resolves.toEqual({ done: true });
     await expect(repeater.next()).resolves.toEqual({ done: true });
+    await expect(repeater.next()).resolves.toEqual({ done: true });
     await expect(repeater.throw(error)).rejects.toBe(error);
+    await expect(repeater.next()).resolves.toEqual({ done: true });
+    await expect(repeater.next()).resolves.toEqual({ done: true });
     await expect(repeater.next()).resolves.toEqual({ done: true });
   });
 
@@ -1274,22 +1277,10 @@ describe("Repeater", () => {
       }
       return -1;
     }, new FixedBuffer(100));
-    await expect(repeater.next()).resolves.toEqual({ value: 1, done: false });
-    await expect(repeater.throw(error)).resolves.toEqual({
-      value: 2,
-      done: false,
-    });
-    await expect(repeater.next()).resolves.toEqual({ value: 3, done: false });
-    await expect(repeater.throw(error)).resolves.toEqual({
-      value: 4,
-      done: false,
-    });
-    await expect(repeater.next()).resolves.toEqual({ value: 5, done: false });
-    await expect(repeater.throw(error)).resolves.toEqual({
-      value: 6,
-      done: false,
-    });
-    await expect(repeater.next()).resolves.toEqual({ value: 7, done: false });
+    await expect(repeater.throw(error)).rejects.toBe(error);
+    await expect(repeater.next()).resolves.toEqual({ done: true });
+    await expect(repeater.next()).resolves.toEqual({ done: true });
+    await expect(repeater.next()).resolves.toEqual({ done: true });
     expect(mock).toHaveBeenCalledTimes(0);
   });
 

--- a/packages/repeater/src/repeater.ts
+++ b/packages/repeater/src/repeater.ts
@@ -342,7 +342,8 @@ class RepeaterController<T, TReturn = any, TNext = any>
   throw(error: any): Promise<IteratorResult<T, TReturn>> {
     if (
       this.state === RepeaterState.Initial ||
-      this.state >= RepeaterState.Stopped
+      this.state >= RepeaterState.Stopped ||
+      !this.buffer.empty
     ) {
       this.execution = Promise.resolve(this.execution).then(() =>
         Promise.reject(error),


### PR DESCRIPTION
Related to #35.