### PR TITLE
feat(website): add DocSearch as recommended by docusaurus.

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -39,6 +39,10 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} Brian Kim`,
     },
   },
+  algolia: {
+    apiKey: '8a93db8e9eb1ba1b8055d703bd55f523',
+    indexName: 'repeater',
+  },
   presets: [
     [
       "@docusaurus/preset-classic",


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.