### PR TITLE
call `then` on promise instead of bool in example

### DIFF
--- a/docs/06_inverted_repeaters.md
+++ b/docs/06_inverted_repeaters.md
@@ -10,7 +10,7 @@ Sometimes you want to create async iterators which respond to calls to `next` as
 const timer = new Repeater(async (push, stop) => {
   const timers = [];
   let stopped = false;
-  stopped.then(() => (stopped = true));
+  stop.then(() => (stopped = true));
   try {
     while (!stopped) {
       let resolve;


### PR DESCRIPTION
In the example about inverted repeaters, you wrote `stopped.then(...)` where `stopped` is a boolean value.
I think you meant `stop.then(...)`.