### PR TITLE
return vs throw

### DIFF
--- a/packages/repeater/src/__tests__/repeater.ts
+++ b/packages/repeater/src/__tests__/repeater.ts
@@ -5,6 +5,7 @@ import {
   FixedBuffer,
   MAX_QUEUE_LENGTH,
   SlidingBuffer,
+  Push,
 } from "../repeater";
 import { delayPromise } from "./_testutils";
 
@@ -1574,4 +1575,29 @@ describe("Repeater", () => {
     await expect(r.next()).resolves.toEqual({ done: true });
     await expect(r.next()).resolves.toEqual({ done: true });
   });
+});
+
+test("return method when awaiting", async () => {
+  let publish!: Push<number>;
+  const subscription = new Repeater(async (push, stop) => {
+    publish = push;
+    await stop;
+  });
+  const payload = subscription.next();
+  await subscription.return();
+  await publish(1);
+  await expect(payload).resolves.toEqual({ done: true });
+});
+
+test("throw method when awaiting", async () => {
+  const error = new Error("throw method when awaiting");
+  let publish!: Push<number>;
+  const subscription = new Repeater(async (push, stop) => {
+    publish = push;
+    await stop;
+  });
+  const payload = subscription.next();
+  await subscription.throw(error);
+  await publish(1);
+  await expect(payload).resolves.toEqual({ value: "hmmmmm", done: true });
 });


### PR DESCRIPTION
Related #72

This is just a short demo showing the difference between return vs throw that causes throw to hang with even simple repeaters when a pending push has not been reached, having nothing actually to do with mapping async iterators/generators/etc.

@brainkim 

I assume this is per spec, and the tests in graphql-js make optimistic? unfair? non-generator-like? assumptions.

@IvanGoncharov